### PR TITLE
Add a generic way to specify extra options, Fix #8

### DIFF
--- a/src/main/java/software/chronicle/ExtraOption.java
+++ b/src/main/java/software/chronicle/ExtraOption.java
@@ -1,0 +1,36 @@
+package software.chronicle;
+
+import org.apache.maven.plugins.annotations.Parameter;
+
+public final class ExtraOption {
+
+    /**
+     * Name of the option (e.g. skip-internal-packages).
+     */
+    @Parameter(name = "name", required = true)
+    String name;
+
+    /**
+     * Value of the option (e.g. *my_internal_package*).
+     */
+    @Parameter(name = "value", required = false)
+    String value;
+
+    public ExtraOption() {
+    }
+
+    public ExtraOption(String name,
+                       String value) {
+        this.name = name;
+        this.value = value;
+    }
+
+    @Override
+    public String toString() {
+        return '-' + name +
+                (value != null && !value.isEmpty()
+                        ? ' ' + value
+                        : ""
+                );
+    }
+}

--- a/src/test/java/software/chronicle/BinaryCompatibilityEnforcerPluginMogoTest.java
+++ b/src/test/java/software/chronicle/BinaryCompatibilityEnforcerPluginMogoTest.java
@@ -1,6 +1,5 @@
 package software.chronicle;
 
-
 import org.apache.maven.plugin.MojoExecutionException;
 import org.junit.Test;
 
@@ -19,6 +18,20 @@ public class BinaryCompatibilityEnforcerPluginMogoTest {
 
         assertEquals("1.2ea0", test("1.2ea3"));
         assertEquals("1.2ea0", test("1.2ea4-SNAPSHOT"));
+    }
+
+    @Test
+    public void ExtraOptionsTest() {
+        String actual = BinaryCompatibilityEnforcerPluginMogo.renderExtraOptions(
+                new ExtraOption[]{
+                        new ExtraOption("skip-internal-packages", "*my-internal-package*"),
+                        new ExtraOption("short", "")
+                }
+        );
+
+        String expected = "-skip-internal-packages *my-internal-package* -short";
+
+        assertEquals(expected, actual);
     }
 
     private String test(String version) throws MojoExecutionException {


### PR DESCRIPTION
Allows, for example, 

```
                        <configuration>
                            <referenceVersion>2.23ea0</referenceVersion>
                            <artifactsURI>https://teamcity.chronicle.software/repository/download</artifactsURI>
                            <binaryCompatibilityPercentageRequired>98.1</binaryCompatibilityPercentageRequired>
                            <extraOptions>
                                <extraOption>
                                    <name>skip-internal-packages</name>
                                    <value>net.openhft.chronicle.wire.incubator</value>
                                </extraOption>
                            </extraOptions>
                        </configuration>

```